### PR TITLE
maintenance: Add docker-compose file for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ __marimo__/
 
 # Django stuff
 staticfiles/
+static/admin/

--- a/README.md
+++ b/README.md
@@ -48,10 +48,19 @@ This guide will walk you through setting up the GridSight project for local deve
 
 3.  **Configure your environment:**
     Create a `.env` file in the project root by copying the example file. This will store your database credentials and other secrets / env vars.
+
+    > Note: For now, the variables have to be exported when running a new process/opening a new terminal.
+
     ```
-    POSTGRES_PASSWORD=YOUR_PASSWORD
     DJANGO_SECRET_KEY=your-secret-key-here
     DJANGO_DEBUG=True
+
+    # Make sure this is aligned with the docker compose file
+    POSTGRES_USER=postgres
+    POSTGRES_PASSWORD=postgres
+    POSTGRES_DB=postgres
+    POSTGRES_HOST=localhost
+    POSTGRES_PORT=5433
     ```
 
 5.  **Run database migrations and collect static files:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: timescale/timescaledb:latest-pg17
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Changes in this MR add a simple  file for development as the app requires the database to be running upon startup.

Closes #1

Once the container is up, the app should start and show the home page. The extension should be in the database container, this can be validated running this plain SQL from a client app:

```
SELECT * FROM pg_extension;
```

Or running the `\dx` command through **psql**.
