### PR TITLE
chore: add redis service to the docker compose stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,13 @@ services:
       POSTGRES_DB: postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
+  redis:
+    image: redis:8.2
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/data
 
 volumes:
   postgres_data:
+  redis_data:


### PR DESCRIPTION
Small PR to add a redis service to the docker compose file. It will be required for Celery.