### PR TITLE
chore: use pydantic settings-based configurations to set up Django settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ This guide will walk you through setting up the GridSight project for local deve
 3.  **Configure your environment:**
     Create a `.env` file in the project root by copying the example file. This will store your database credentials and other secrets / env vars.
 
-    > Note: For now, the variables have to be exported when running a new process/opening a new terminal.
-
     ```
     DJANGO_SECRET_KEY=your-secret-key-here
     DJANGO_DEBUG=True
@@ -61,6 +59,9 @@ This guide will walk you through setting up the GridSight project for local deve
     POSTGRES_DB=postgres
     POSTGRES_HOST=localhost
     POSTGRES_PORT=5433
+
+    # Once you have a BMRS API key
+    BMRS_API_KEY=your-cool-and-secret-bmrs-key
     ```
 
 5.  **Run database migrations and collect static files:**

--- a/app/configuration/app.py
+++ b/app/configuration/app.py
@@ -1,0 +1,9 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AppSettings(BaseSettings):
+    bmrs_api_key: str
+
+    model_config = SettingsConfigDict(extra="ignore")
+
+app_settings = AppSettings()

--- a/app/configuration/django.py
+++ b/app/configuration/django.py
@@ -1,0 +1,13 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DjangoSettings(BaseSettings):
+    secret_key: str
+    debug: bool = False
+
+    model_config = SettingsConfigDict(
+        env_prefix="DJANGO_",
+        extra="ignore",
+    )
+
+django_settings = DjangoSettings()

--- a/app/configuration/postgres.py
+++ b/app/configuration/postgres.py
@@ -1,0 +1,16 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class PostgresSettings(BaseSettings):
+    host: str
+    port: int
+    user: str
+    password: str
+    db: str
+
+    model_config = SettingsConfigDict(
+        env_prefix="POSTGRES_",
+        extra="ignore",
+    )
+
+postgres_settings = PostgresSettings()

--- a/app/settings.py
+++ b/app/settings.py
@@ -10,20 +10,21 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
-import os
 from pathlib import Path
+from app.configuration.django import django_settings
+from app.configuration.postgres import postgres_settings
+from app.configuration.app import app_settings
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
-SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+SECRET_KEY = django_settings.secret_key
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() in ("true", "1", "yes")
+DEBUG = django_settings.debug
 
 ALLOWED_HOSTS = [
     "gridsight.a115.co.uk",
@@ -96,11 +97,11 @@ WSGI_APPLICATION = "app.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "timescale.db.backends.postgresql",
-        "NAME": os.environ.get("POSTGRES_DB", "gridsight"),
-        "USER": os.environ.get("POSTGRES_USER", "nobody"),
-        "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
-        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
-        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        "NAME": postgres_settings.db,
+        "USER": postgres_settings.user,
+        "PASSWORD": postgres_settings.password,
+        "HOST": postgres_settings.host,
+        "PORT": postgres_settings.port,
     }
 }
 
@@ -150,4 +151,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
 # API Keys and other sensitive settings
-BMRS_API_KEY = os.environ.get("BMRS_API_KEY")
+BMRS_API_KEY = app_settings.bmrs_api_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ requests
 pandas
 gunicorn
 whitenoise[brotli]
+pydantic
+pydantic-settings


### PR DESCRIPTION
As per the title really. Django and Postgres settings are included for now, will probably add Redis as part of the PR to create the Celery app.

Closes #9
