### PR TITLE
chore: add simple Celery app and dummy task for 'live plants' pipeline

### DIFF
--- a/app/configuration/celery.py
+++ b/app/configuration/celery.py
@@ -1,0 +1,23 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class CelerySettings(BaseSettings):
+    redis_host: str
+    redis_port: int
+    redis_user: str
+    redis_password: str
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @property
+    def broker_url(self) -> str:
+        return f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}"
+
+    @property
+    def result_backend(self) -> str:
+        return f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}"
+
+celery_settings = CelerySettings()

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,3 @@
+from .celery_pipeline.celery import etl_app
+
+__all__ = ("etl_app",)

--- a/etl/celery_pipeline/celery.py
+++ b/etl/celery_pipeline/celery.py
@@ -1,0 +1,19 @@
+from celery import Celery
+from app.configuration.celery import celery_settings
+
+
+etl_app = Celery(
+    main="GridSight",
+    broker=celery_settings.broker_url,
+    backend=celery_settings.result_backend,
+)
+
+etl_app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    enable_utc=True,
+    broker_connection_retry_on_startup=True,
+)
+
+etl_app.autodiscover_tasks()

--- a/etl/celery_pipeline/live_plants/tasks.py
+++ b/etl/celery_pipeline/live_plants/tasks.py
@@ -1,0 +1,8 @@
+from etl.celery_pipeline.celery import etl_app as app
+import logfire
+
+
+@app.task(bind=True, ignore_result=True)
+def ingest_plants_data(self):
+    # TODO: Implement the logic to ingest plants data
+    logfire.info("Ingesting plants data")

--- a/todo.md
+++ b/todo.md
@@ -8,9 +8,4 @@ Product:
 3. Plug in some data into the mock **Live Plant Status board** dashboard
 
 Shared app setup/infra:
-
-1. Set up simple settings loading with `pydantic-settings`
-    - Configure Postgres settings
-    - Configure Celery settings
-2. Set up Celery broker container
-3. Set up simple Celery app and add a healthcheck task
+- Add healthcheck Celery task


### PR DESCRIPTION
Changes in the PR add a simple Celery app that can be used for data ingestion pipelines. New tasks can be added under the 'etl' module.